### PR TITLE
web worker compatibility check, handle fallback timing method

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,19 @@ const instrumentile = require('@mapbox/instrumentile-gl');
 
 mapboxgl.accessToken = VALID_ACCESS_TOKEN;
 
-const map = new mapboxgl.Map({
-    container: 'map',
-    style: 'mapbox://styles/mapbox/streets-v9',
-    collectResourceTiming: true /* <-- mandatory for instrumentile-gl */
-});
+// optional check for web worker performance API support -- avoids errors on Mapbox GL 0.44 & 0.45
+instrumentile.supportsWebWorkerPerformanceCollection(function(err, supported) {
+    const map = new mapboxgl.Map({
+        container: 'map',
+        style: 'mapbox://styles/mapbox/streets-v9',
+        collectResourceTiming: supported
+    });
 
-var inst = instrumentile(map, {
-    token: VALID_ACCESS_TOKEN,
-    api: 'https://api.tiles.mapbox.com', // this is the default
-    source: 'whatevs' // optional source string that is sent along every event
+    const inst = new instrumentile(map, {
+        token: VALID_ACCESS_TOKEN,
+        api: 'https://api.tiles.mapbox.com', // this is the default
+        source: 'whatevs' // optional source string that is sent along every event
+    });
 });
 ```
 

--- a/html/index.html
+++ b/html/index.html
@@ -7,28 +7,30 @@
 <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.0/mapbox-gl.css' rel='stylesheet' />
 <style>
   body { margin:0; padding:0; }
-  #map { position:absolute; top:0; bottom:0; width:100%; }
+  #map { position:absolute; top:0; bottom:0; width:100%; height: 100%; }
   #diagnostic { position: absolute; top: 1em; left: 1em; background-color: rgba(255, 255, 255, 0.8); z-index: 9; padding: 0.5em; font-family: helvetica, arial, sans-serif; font-size: 16pt;}
   #diagnostic h2 { margin-top: 0; }
   #diagnostic ul { list-style: none; padding: 0; margin: 0;}
   #diagnostic li span { color: red; margin-right: 0.5em; }
   #diagnostic li.success span { color: green; }
+  #diagnostic li.na { color: #aaa; }
+  #diagnostic li.na span { color: yellow; }
 }
 </style>
 </head>
 <body>
 <div id='map'></div>
 <div id='diagnostic'>
-	<h2>Instrumentile Events</h2>
-	<ul>
-		<li id="map-load"><span>X</span>map.load</li>
-		<li id="source-vt"><span>X</span>source.vt</li>
-		<li id="source-geojson-load"><span>X</span>source.geojson (source load)</li>
-		<li id="source-geojson-setdata"><span>X</span>source.geojson (setData)</li>
-		<li id="map-click"><span>X</span>map.click</li>
-		<li id="map-dragend"><span>X</span>map.dragend</li>
-		
-	</ul>
+    <h2>Instrumentile Events</h2>
+    <ul>
+        <li id="supports"><span>X</span>Instrumentile.supportsWebWorkerPerformanceCollection (in supported browsers)</li>
+        <li id="map-load"><span>X</span>map.load</li>
+        <li id="source-vt"><span>X</span>source.vt</li>
+        <li id="source-geojson-load"><span>X</span>source.geojson (source load)</li>
+        <li id="source-geojson-setdata"><span>X</span>source.geojson (setData)</li>
+        <li id="map-click"><span>X</span>map.click</li>
+        <li id="map-dragend"><span>X</span>map.dragend</li>
+    </ul>
 </div>
 <script src="bundle.js"></script>
 </body>

--- a/html/index.js
+++ b/html/index.js
@@ -11,63 +11,98 @@ function isNumeric(n) {
 
 document.addEventListener('DOMContentLoaded', function () {
     mapboxgl.accessToken = TOKEN;
-    var map = new mapboxgl.Map({
-        container: 'map',
-        style: 'mapbox://styles/mapbox/streets-v9',
-        collectResourceTiming: true,
-        hash: true,
-        center: [-77.0574, 38.8937],
-        zoom: 12
-    });
 
-    instrumentile(map, {
-        token: TOKEN,
-        source: 'integrationtest',
-        stub: {
-            events: {
-                push: function (e) {
-                    // check if event looks ok
-                    var numericProps = ['DNS', 'TCP', 'request', 'response', 'timeTaken', 'transferSize', 'encodedBodySize', 'decodedBodySize'];
-                    if ((e.event === 'instrumentile.map.dragend') || (e.event === 'instrumentile.map.click'))
-                        numericProps = ['lat', 'lng', 'zoom'];
-                    else if (e.event === 'instrumentile.map.load')
-                        numericProps = ['DNS', 'TCP', 'appCache', 'lat', 'lng', 'loadtime', 'request', 'response', 'zoom'];
-                    if (!numericProps.every(function (p) {
-                        var res = (e[p] || (e[p] === 0)) && isNumeric(e[p]);
-                        if (!res)
-                            console.error('event ' + e.event + ' property ' + p + ' is not numeric');
-                        return res;
-                    }))
-                        return;
-                    if (e.source !== 'integrationtest')
-                        return;
+    instrumentile.supportsWebWorkerPerformanceCollection(function (err, supported) {
+        if (err) return;
 
-                    // note its reception
-                    var elemName = e.event.replace('instrumentile.', '').replace(/\./g, '-');
-                    if (elemName === 'source-geojson')
-                        elemName += '-' + (e.url.indexOf('step1') !== -1 ? 'load' : 'setdata');
-                    var elem = document.getElementById(elemName);
-                    if (elem) {
-                        // this code should use awesome CSS pseudoclass/content trickery, but alas MS Edge is not
-                        // reliable at refreshing its render when you do that
-                        elem.className = 'success';
-                        elem.children[0].innerText = '✔';
+        var elem = document.getElementById('supports');
+        if (elem) {
+            elem.className = supported ? 'success' : 'success (but not supported)';
+            elem.children[0].innerText = '✔';
+        }
+
+        if (!supported) {
+            ['source-geojson-load', 'source-geojson-setdata', 'source-vt'].forEach(function (p) {
+                var elem = document.getElementById(p);
+                if (elem) {
+                    elem.className = 'na';
+                    elem.children[0].innerText = '?';
+                }
+            });
+        }
+
+        var map = new mapboxgl.Map({
+            container: 'map',
+            style: 'mapbox://styles/mapbox/streets-v9',
+            collectResourceTiming: supported,
+            hash: true,
+            center: [-77.0574, 38.8937],
+            zoom: 12
+        });
+
+        window.instrumentileHandle = new instrumentile(map, {
+            token: TOKEN,
+            source: 'integrationtest',
+            stub: {
+                events: {
+                    push: function (e) {
+                        // check if event looks ok
+                        var numericProps = ['timeTaken'];
+                        var optionalNumericProps = ['DNS', 'TCP', 'request', 'response', 'transferSize', 'encodedBodySize', 'decodedBodySize'];
+                        if ((e.event === 'instrumentile.map.dragend') || (e.event === 'instrumentile.map.click')) {
+                            numericProps = ['lat', 'lng', 'zoom'];
+                            optionalNumericProps = [];
+                        } else if (e.event === 'instrumentile.map.load') {
+                            numericProps = ['DNS', 'TCP', 'appCache', 'lat', 'lng', 'loadtime', 'request', 'response', 'zoom'];
+                            optionalNumericProps = [];
+                        }
+                        var numericPropsOk = numericProps.every(function (p) {
+                            var res = (e[p] || (e[p] === 0)) && isNumeric(e[p]);
+                            if (!res)
+                                console.error('event ' + e.event + ' property ' + p + ' is not numeric');
+                            return res;
+                        });
+                        var optionalNumericPropsOk = optionalNumericProps.every(function (p) {
+                            if (!e[p]) {
+                                console.warn('propery ' + e.event + '/' + p + ' not found but it is optional');
+                            } else if (!isNumeric(e[p])) {
+                                console.error('property ' + e.event + '/' + p + ' is optional but it was found and is NOT numeric, which is disallowed');
+                                return false;
+                            }
+                            return true;
+                        });
+                        if (!numericPropsOk || !optionalNumericPropsOk)
+                            return;
+                        if (e.source !== 'integrationtest')
+                            return;
+
+                        // note its reception
+                        var elemName = e.event.replace('instrumentile.', '').replace(/\./g, '-');
+                        if (elemName === 'source-geojson')
+                            elemName += '-' + (e.url.indexOf('step1') !== -1 ? 'load' : 'setdata');
+                        var elem = document.getElementById(elemName);
+                        if (elem) {
+                            // this code should use awesome CSS pseudoclass/content trickery, but alas MS Edge is not
+                            // reliable at refreshing its render when you do that
+                            elem.className = 'success';
+                            elem.children[0].innerText = '✔';
+                        }
                     }
                 }
             }
-        }
-    });
-
-    map.on('load', () => {
-        console.log('- map loaded. loading GeoJSON...');
-        map.addSource('blah', {
-            type: 'geojson',
-            data: 'step1.geojson'
         });
 
-        window.setTimeout(function () {
-            console.log('- loading second GeoJSON...');
-            map.getSource('blah').setData('step2.geojson');
-        }, 1000);
+        map.on('load', function () {
+            console.log('- map loaded. loading GeoJSON...');
+            map.addSource('blah', {
+                type: 'geojson',
+                data: 'step1.geojson'
+            });
+
+            window.setTimeout(function () {
+                console.log('- loading second GeoJSON...');
+                map.getSource('blah').setData('step2.geojson');
+            }, 1000);
+        });
     });
 });

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
           "newIsCap": false
         }
       ]
+    },
+    "globals": {
+      "BlobBuilder": true
     }
   },
   "author": "Tom Lee <tlee@mapbox.com>",


### PR DESCRIPTION
- adds `instrumentile. supportsWebWorkerPerformanceCollection()` static method to check for existence of `performance` object in web worker context. This helps to avoid a JS error when invoking Mapbox GL JS with `collectResourceTiming: true` in older browsers for MBXGLJS versions prior to https://github.com/mapbox/mapbox-gl-js/pull/6695 (unpublished as of this writing)
- changes the signature of the main export to accommodate ^^^
- handles data events produced by `performance.measure()` (a fallback method for buggy browsers pending in https://github.com/mapbox/mapbox-gl-js/pull/6721)
- only checks for `map._collectResourceTiming` on data events, since `click`, `dragend` and `load` are all on the main thread and work fine without it.